### PR TITLE
Problème de requête trop longue

### DIFF
--- a/geography/getPlacesPosition.js
+++ b/geography/getPlacesPosition.js
@@ -2,7 +2,7 @@ import {json} from 'd3-fetch'
 
 export default function(places){
     console.log('places', places)
-    return json(`/positions?${([...places].map(p => `places[]=${encodeURIComponent(p)}`).join('&'))}`)
+    return json(`/positions?${([...places].map(p => `p=${encodeURIComponent(p)}`).join('&'))}`)
     .then(positionObject => (new Map(Object.entries(positionObject))))
 }
 

--- a/server.js
+++ b/server.js
@@ -23,8 +23,13 @@ app.get('/driver-trip-proposals', (req, res) => {
 })
 
 app.get('/positions', (req, res) => {
-    const {places} = req.query;
-
+    /* In order to reduce the risk of max GET header size limit, 
+        - p is a shorthand for places
+        - we use the p=a&p=2 syntax instead of p[]=a&p[]=2, and treat the edge case of a single element array
+    */ 
+    const {p: placeOrPlaces} = req.query
+    const places = Array.isArray(placeOrPlaces) ? placeOrPlaces : [placeOrPlaces]
+    
     const result = Object.create(null)
 
     const placesWithoutPositions = new Set(places);


### PR DESCRIPTION
On réduit le risque en racourcissant la requête. Il faut peut-être
passer à un POST, car après tout, on écrit des données dans un cache
côté serveur ?