### PR TITLE
Mvp direct

### DIFF
--- a/direct/components/DriverList.js
+++ b/direct/components/DriverList.js
@@ -58,9 +58,8 @@ function TripProposal({
 		>
 			<section className="${detourClassName} trip-details">
 				<span
-					>${tripDetails
-						? `+${Math.ceil(additionalTime)}mins`
-						: undefined}</span
+					>${tripDetails && 'détour'}<br />
+					${tripDetails ? `${Math.ceil(additionalTime)}mins` : undefined}</span
 				>
 			</section>
 			<section>

--- a/direct/components/DriverList.js
+++ b/direct/components/DriverList.js
@@ -83,7 +83,7 @@ const StandardContact = ({}) => {
 
 export default function DriversList({
 	tripProposalsByTrip,
-	tripRequest,
+	validTripRequest,
 	tripDetailsByTrip,
 	displayedDriverTrips,
 	onTripClick
@@ -104,6 +104,18 @@ export default function DriversList({
 		return detour1 - detour2
 	})
 
+	if (!orderedTrips.length) return null
+	if (!validTripRequest)
+		return html`
+			<div style=${{ textAlign: 'center', marginTop: '2rem' }}>
+				<p style=${{ marginBottom: '0rem' }}>
+					${orderedTrips.length} trajets disponibles sur Lotocar
+				</p>
+				<a href="http://bit.ly/inscription-conducteur"
+					>J'ai une voiture et je veux aider</a
+				>
+			</div>
+		`
 	return html`
 		<h2 key="h2">Conducteur.rice.s</h2>
 		<ul key="ul" className="drivers-list">

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -6,21 +6,17 @@ import {
 	STATUS_ERROR,
 	STATUS_VALUE
 } from '../asyncStatusHelpers'
-import { take } from 'lodash-es'
+import { json } from 'd3-fetch'
 
 const html = htm.bind(React.createElement)
 
 const searchCity = (input, setOptions) =>
-	fetch(
+	json(
 		`https://geo.api.gouv.fr/communes?nom=${input}&fields=nom,code,departement,region&boost=population`
 	)
-		.then(response => {
-			if (!response.ok) return setOptions([])
-			return response.json()
-		})
 		.then(json => setOptions(json))
 		.catch(function(error) {
-			console.log(
+			console.error(
 				'Erreur dans la recherche de communes à partir du code postal',
 				error
 			)
@@ -86,8 +82,8 @@ export default function TripRequestEntry({ tripRequest, onTripRequestChange }) {
 const Options = ({ options, onClick }) =>
 	html`
 		<ul style=${{ width: '100%' }}>
-			${take(
-				options.map(
+			${options
+				.map(
 					({ nom, departement }) =>
 						html`
 							<li
@@ -108,9 +104,8 @@ const Options = ({ options, onClick }) =>
 								</span>
 							</li>
 						`
-				),
-				5
-			)}
+				)
+				.slice(0, 5)}
 		</ul>
 	`
 

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -98,7 +98,7 @@ const Options = ({ options, onClick }) =>
 										color:
 											departement && departement.nom === 'Lot'
 												? 'green'
-												: 'orange'
+												: 'grey'
 									}}
 									>${departement ? ' (' + departement.nom + ')' : ''}
 								</span>

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -102,7 +102,16 @@ const Options = ({ options, onClick }) =>
 					({ nom, departement }) =>
 						html`
 							<li onClick=${nom => onClick(nom)}>
-								${nom + (departement ? ' (' + departement.nom + ')' : '')}
+								<span> ${nom}</span
+								><span
+									style=${{
+										color:
+											departement && departement.nom === 'Lot'
+												? 'green'
+												: 'orange'
+									}}
+									>${departement ? ' (' + departement.nom + ')' : ''}
+								</span>
 							</li>
 						`
 				),

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -85,7 +85,7 @@ export default function TripRequestEntry({ tripRequest, onTripRequestChange }) {
 
 const Options = ({ options, onClick }) =>
 	html`
-		<ul style=${{ width: '100%', textAlign: 'center' }}>
+		<ul style=${{ width: '100%' }}>
 			${take(
 				options.map(
 					({ nom, departement }) =>

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -65,7 +65,7 @@ export default function TripRequestEntry({ tripRequest, onTripRequestChange }) {
 	let requestStatus = tripRequest[ASYNC_STATUS]
 
 	return html`
-		<h2 key="h2">Demande de trajet</h2>
+		<h2 key="h2">Où allez-vous ?</h2>
 		<form key="form" className="trip-request-entry">
 			<section className="geography">
 				<${CityInput} label="Départ" input=${origin} setInput=${setOrigin} />

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -27,81 +27,75 @@ const searchCity = (input, setOptions) =>
 			setOptions([])
 		})
 
+const CityInput = ({ label, input, setInput }) => {
+	const [options, setOptions] = useState([])
+
+	return html`
+		<div>
+			<label>
+				<strong>${label}</strong>
+				<input
+					type="text"
+					value=${input.text}
+					onChange=${e => {
+						const value = e.target.value
+						setInput({ text: value, validated: false })
+						if (value.length > 2) searchCity(e.target.value, setOptions)
+						// Vérifier qu'aucune ville n'est exclue : https://fr.wikipedia.org/wiki/Liste_de_toponymes_courts
+					}}
+				/>
+				${input.validated && '✔'}
+			</label>
+			${!input.validated &&
+				html`
+					<${Options} options=${options} onClick=${setInput} />
+				`}
+		</div>
+	`
+}
 export default function TripRequestEntry({ tripRequest, onTripRequestChange }) {
-	const [origin, setOrigin] = useState(tripRequest.origin)
-	const [destination, setDestination] = useState(tripRequest.destination)
-	const [originOptions, setOriginOptions] = useState([])
-	const [destinationOptions, setDestinationOptions] = useState([])
+	const [origin, setOrigin] = useState({ text: '', validated: false })
+	const [destination, setDestination] = useState({ text: '', validated: false })
 
-	// pass new trip to state if it came from props
 	useEffect(() => {
-		setOrigin(tripRequest.origin)
-	}, [tripRequest.origin])
-	useEffect(() => {
-		setDestination(tripRequest.destination)
-	}, [tripRequest.destination])
+		origin.validated &&
+			destination.validated &&
+			onTripRequestChange({
+				origin: origin.text,
+				destination: destination.text
+			})
+	}, [origin, destination])
 
-	function onSubmit(e) {
-		e.preventDefault()
-		onTripRequestChange({
-			origin,
-			destination
-		})
-	}
 	let requestStatus = tripRequest[ASYNC_STATUS]
 
 	return html`
 		<h2 key="h2">Demande de trajet</h2>
-		<form key="form" className="trip-request-entry" onSubmit=${onSubmit}>
+		<form key="form" className="trip-request-entry">
 			<section className="geography">
-				<label>
-					<strong>Départ</strong>
-					<input
-						className="origin"
-						type="text"
-						onChange=${e => {
-							const value = e.target.value
-							if (value.length > 2) searchCity(e.target.value, setOriginOptions)
-						}}
-					/>
-				</label>
-				${!origin &&
-					html`
-						<${Options} options=${originOptions} onClick=${setOrigin} />
-					`}
-				<label>
-					<strong>Arrivée</strong>
-					<input
-						className="destination"
-						type="text"
-						onChange=${e => {
-							const value = e.target.value
-							if (value.length > 2)
-								searchCity(e.target.value, setDestinationOptions)
-						}}
-					/>
-				</label>
-				${!destination &&
-					html`
-						<${Options}
-							options=${destinationOptions}
-							onClick=${setDestination}
-						/>
-					`}
+				<${CityInput} label="Départ" input=${origin} setInput=${setOrigin} />
+				<${CityInput}
+					label="Arrivée"
+					input=${destination}
+					setInput=${setDestination}
+				/>
 			</section>
 		</form>
 	`
 }
 
 const Options = ({ options, onClick }) =>
-	console.log('incomptop', options) ||
 	html`
-		<ul>
+		<ul style=${{ width: '100%', textAlign: 'center' }}>
 			${take(
 				options.map(
 					({ nom, departement }) =>
 						html`
-							<li onClick=${nom => onClick(nom)}>
+							<li
+								style=${{
+									cursor: 'pointer'
+								}}
+								onClick=${() => onClick({ text: nom, validated: true })}
+							>
 								<span> ${nom}</span
 								><span
 									style=${{

--- a/direct/components/TripSelection.js
+++ b/direct/components/TripSelection.js
@@ -26,6 +26,8 @@ export default function({
 				tripDetailsByTrip=${tripDetailsByTrip}
 				displayedDriverTrips=${displayedDriverTrips}
 				onTripClick=${onTripClick}
+				validTripRequest=${tripRequest.destination !== '' &&
+					tripRequest.origin !== ''}
 			/>
 		</section>
 	`

--- a/direct/index.html
+++ b/direct/index.html
@@ -59,10 +59,6 @@
             }
 
             .trip-request-entry .geography{
-                display: flex;
-                flex-direction: row;
-                 flex-wrap: wrap;
-                justify-content: center;
             }
             .trip-request-entry .geography label{
                 text-align: center;

--- a/direct/main.js
+++ b/direct/main.js
@@ -117,6 +117,5 @@ json('/driver-trip-proposals').then(tripProposals => {
 		currentEntries.push(tripProposal)
 		tripProposalsByTrip.set(trip, currentEntries)
 	}
-	debugger
 	store.mutations.addTripProposals(tripProposalsByTrip)
 })

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,6 +35,7 @@ function makePlugins() {
 					'GeoJSON',
 					'GridLayer',
 					'ImageOverlay',
+					'SVGOverlay',
 					'latLngBounds',
 					'LayerGroup',
 					'Map',

--- a/spreadsheetDatabase/getLotocarPositionByPlace.js
+++ b/spreadsheetDatabase/getLotocarPositionByPlace.js
@@ -1,46 +1,56 @@
 import { google } from 'googleapis'
 
 const googleAPIKey = process.env.GOOGLE_API_KEY
-const googleDriverSpreadsheetId = process.env.LOCALISATION_KNOWLEDGE_GOOGLE_SPREADSHEET_ID
+const googleDriverSpreadsheetId =
+	process.env.LOCALISATION_KNOWLEDGE_GOOGLE_SPREADSHEET_ID
 
-const sheets = google.sheets({ version: 'v4', auth: googleAPIKey });
+const sheets = google.sheets({ version: 'v4', auth: googleAPIKey })
 
 // This function provides local-specific knowledge about positions in the Lot
 export default function getLotocarPositionByPlace() {
-    return new Promise((resolve, reject) => {
-        sheets.spreadsheets.values.get({
-            spreadsheetId: googleDriverSpreadsheetId,
-            range: 'Feuille 1',
-        }, (err, res) => {
-            if (err){
-                reject(err)
-            }
-            else{
-                const rows = res.data.values;
-    
-                // first row is column names, ignoring
-                const dataRows = rows.slice(1)
-        
-                const positionByPlace = new Map()
+	return new Promise((resolve, reject) => {
+		sheets.spreadsheets.values.get(
+			{
+				spreadsheetId: googleDriverSpreadsheetId,
+				range: 'Feuille 1'
+			},
+			(err, res) => {
+				if (err) {
+					reject(err)
+				} else {
+					const rows = res.data.values
 
-                for(const row of dataRows){
-                    const [namesStr, latitudeStr, longitudeStr] = row;
-                    
-                    const names = namesStr
-                        .split(',')
-                        .map(n => n.trim())
-                        .filter(s => s.length >= 1)
-                    
-                    const [latitude, longitude] = [latitudeStr, longitudeStr].map(str => parseFloat(str))
+					// first row is column names, ignoring
+					const dataRows = rows.slice(1)
 
-                    for(const name of names){
-                        if(name && name.length >= 1 && Number.isFinite(latitude) && Number.isFinite(longitude))
-                        positionByPlace.set(name, {latitude, longitude})
-                    }
-                }
+					const positionByPlace = new Map()
 
-                resolve(positionByPlace)
-            }
-        });
-    })
+					for (const row of dataRows.filter(row => row.length > 0)) {
+						const [namesStr, latitudeStr, longitudeStr] = row
+
+						const names = namesStr
+							.split(',')
+							.map(n => n.trim())
+							.filter(s => s.length >= 1)
+
+						const [latitude, longitude] = [latitudeStr, longitudeStr].map(str =>
+							parseFloat(str)
+						)
+
+						for (const name of names) {
+							if (
+								name &&
+								name.length >= 1 &&
+								Number.isFinite(latitude) &&
+								Number.isFinite(longitude)
+							)
+								positionByPlace.set(name, { latitude, longitude })
+						}
+					}
+
+					resolve(positionByPlace)
+				}
+			}
+		)
+	})
 }


### PR DESCRIPTION
Je pars du constat que les utilisateurs de l'outil direct feront des erreurs dans la saisie des villes. L'exemple typique est celui-ci : 

- Lhospitalet est une commune du Lot
- L'hospitalet est une ville des alpes de haute provence

Nous avons décidé (pour l'instant) d'enlever la carte, donc il me semble intéressant de forcer l'utilisateur à saisir une ville qui est reconnue par l'API géo.

Cette PR règle aussi le problème du message de statut de la requête de recherche de ville.

- [ ] Enlever le code du statut de la reqûete de ville, ou le recycler pour la requête des trajets
- [ ] Quand il n'y a qu'une seule proposition, la valider automatiquement ?

- [ ] tester l'autocompletion avec le tableau de correspondance de Nathalie