### PR TITLE
Suivi des utilisateurs via l'instance Matomo stats.data.gouv.fr

### DIFF
--- a/direct/components/Main.js
+++ b/direct/components/Main.js
@@ -5,6 +5,7 @@ import TripSelection from './TripSelection.js'
 import logo from '../logo.png'
 import logoLot from '../logo-lot.png'
 import styled from 'styled-components'
+import Privacy from './Privacy'
 
 const html = htm.bind(React.createElement)
 
@@ -80,6 +81,7 @@ const Footer = () => html`
 					<div>
 						Tél : 05 31 60 09 03
 					</div>
+					<${Privacy}/>
 					<div><a href="https://6b49e0e7-23a4-497b-931e-cb12669b2b05.filesusr.com/ugd/8db2ce_bfddb80831494ecc832301c3a4dc0105.pdf">Conditions générales d'utilisation</a></div>
 				</section>
 			</footer>

--- a/direct/components/Overlay.js
+++ b/direct/components/Overlay.js
@@ -1,0 +1,77 @@
+import FocusTrap from 'focus-trap-react'
+import React, { useEffect } from 'react'
+import htm from 'htm'
+import styled from 'styled-components'
+
+const html = htm.bind(React.createElement)
+
+export default function Overlay({ onClose, children }) {
+	return html`
+		<${styled.div`
+			position: fixed;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background: rgba(255, 255, 255, 0.9);
+			overflow: auto;
+			z-index: 1;
+			color: initial;
+			#overlayContent {
+				position: absolute;
+				padding-bottom: 1rem;
+				min-height: 6em;
+
+				box-shadow: 0 1px 3px rgba(41, 117, 209, 0.12),
+					0 1px 2px rgba(41, 117, 209, 0.24);
+				padding-left: 1rem;
+				padding-right: 1rem;
+				background: white;
+				will-change: transform;
+				user-select: text;
+				border-radius: 0.3rem;
+				transition: box-shadow 0.2s;
+			}
+			#overlayCloseButton {
+				position: absolute;
+				top: 0rem;
+				text-decoration: none;
+				font-size: 200%;
+				color: rgba(51, 51, 80, 0.8);
+				right: 0.5rem;
+			}
+			@media (min-width: 600px) {
+				#overlayContent {
+					transform: translateX(-50%);
+					top: 100px;
+					left: 50%;
+					width: 80%;
+					max-width: 40em;
+				}
+			}
+		`} id="overlayWrapper">
+			<${FocusTrap}
+				focusTrapOptions=${{
+					onDeactivate: onClose,
+					clickOutsideDeactivates: !!onClose
+				}}>
+				<div
+					aria-modal="true"
+					id="overlayContent">
+					${onClose &&
+						html`
+							<a
+								aria-label="close"
+								href="#"
+								onClick=${onClose}
+								id="overlayCloseButton"
+							>
+								×
+							</a>
+						`}
+					${children}
+				</div>
+			</${FocusTrap}>
+		</div>
+	`
+}

--- a/direct/components/Privacy.js
+++ b/direct/components/Privacy.js
@@ -1,0 +1,55 @@
+import Overlay from './Overlay'
+import React, { useState } from 'react'
+import htm from 'htm'
+import styled from 'styled-components'
+
+const html = htm.bind(React.createElement)
+
+export default function Privacy() {
+	const [opened, setOpened] = useState(false)
+
+	const handleClose = () => {
+		setOpened(false)
+	}
+	const handleOpen = () => {
+		setOpened(true)
+	}
+
+	return html`
+		<${styled.a``} key="vie-privée" href="#" onClick=${handleOpen}>
+			Vie privée
+		</a>
+		${opened &&
+			html`
+				<${Overlay} onClose=${handleClose} >
+					<${PrivacyContent} />
+				</${Overlay}>
+			`}
+	`
+}
+
+export let PrivacyContent = ({}) => html`
+	<h1>Vie privée</h1>
+	<p>
+		Nous recueillons des statistiques anonymes sur l'utilisation du site, que
+		nous utilisons dans le seul but d'améliorer le service, conformément
+		aux${' '}
+		<a
+			href="https://www.cnil.fr/fr/solutions-pour-les-cookies-de-mesure-daudience"
+		>
+			recommandations de la CNIL </a
+		>et au règlement RGPD. Ce sont les seules données qui quittent votre
+		navigateur.
+	</p>
+	<p>
+		Vous pouvez vous soustraire de cette mesure d'utilisation du site
+		ci-dessous.
+	</p>
+	<${styled.iframe`
+		border: 0;
+		height: 200px;
+		width: 100%;
+	`}
+		src=${`https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut`}
+	/>
+`

--- a/direct/components/Privacy.js
+++ b/direct/components/Privacy.js
@@ -16,7 +16,7 @@ export default function Privacy() {
 	}
 
 	return html`
-		<${styled.a``} key="vie-privée" href="#" onClick=${handleOpen}>
+		<a key="vie-privée" href="#" onClick=${handleOpen}>
 			Vie privée
 		</a>
 		${opened &&
@@ -28,7 +28,7 @@ export default function Privacy() {
 	`
 }
 
-export let PrivacyContent = ({}) => html`
+export let PrivacyContent = ({}) => html`<${React.Fragment}>
 	<h1>Vie privée</h1>
 	<p>
 		Nous recueillons des statistiques anonymes sur l'utilisation du site, que
@@ -52,4 +52,5 @@ export let PrivacyContent = ({}) => html`
 	`}
 		src=${`https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut`}
 	/>
+	</${React.Fragment}>
 `

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -77,7 +77,7 @@ export default function TripRequestEntry({ tripRequest, onTripRequestChange }) {
 				origin: origin.text,
 				destination: destination.text
 			})
-			_paq &&
+			if (_paq)
 				_paq.push([
 					'trackEvent',
 					'trajets',

--- a/direct/components/TripRequestEntry.js
+++ b/direct/components/TripRequestEntry.js
@@ -72,12 +72,19 @@ export default function TripRequestEntry({ tripRequest, onTripRequestChange }) {
 	})
 
 	useEffect(() => {
-		origin.validated &&
-			destination.validated &&
+		if (origin.validated && destination.validated) {
 			onTripRequestChange({
 				origin: origin.text,
 				destination: destination.text
 			})
+			_paq &&
+				_paq.push([
+					'trackEvent',
+					'trajets',
+					'recherche',
+					origin.text + ' | ' + destination.text
+				])
+		}
 	}, [origin, destination])
 
 	return html`

--- a/direct/index.html
+++ b/direct/index.html
@@ -167,6 +167,29 @@
 			}
 		</style>
 
+		<!-- Matomo -->
+
+		<script type="text/javascript">
+			var _paq = window._paq || []
+			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+			_paq.push(['trackPageView'])
+			_paq.push(['enableLinkTracking'])
+			;(function() {
+				var u = '//stats.data.gouv.fr/'
+				_paq.push(['setTrackerUrl', u + 'piwik.php'])
+				_paq.push(['setSiteId', '101'])
+				var d = document,
+					g = d.createElement('script'),
+					s = d.getElementsByTagName('script')[0]
+				g.type = 'text/javascript'
+				g.async = true
+				g.defer = true
+				g.src = u + 'piwik.js'
+				s.parentNode.insertBefore(g, s)
+			})()
+		</script>
+		<!-- End Matomo Code -->
+
 		<script type="module" src="build/bundle.js"></script>
 	</head>
 	<body></body>

--- a/direct/index.html
+++ b/direct/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="referrer" content="same-origin" />
 
-		<title>Trouver des conducteurs pertients - Lotocar</title>
+		<title>Trouver un trajet - Lotocar</title>
 
 		<meta
 			name="Description"

--- a/direct/index.html
+++ b/direct/index.html
@@ -169,7 +169,7 @@
 
 		<!-- Matomo -->
 
-		<script type="text/javascript">
+		<script>
 			var _paq = window._paq || []
 			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 			_paq.push(['trackPageView'])

--- a/outil-metier/Corresplot/index.html
+++ b/outil-metier/Corresplot/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="referrer" content="same-origin" />
 
-		<title>Trouver des conducteurs pertients - Lotocar</title>
+		<title>Trouver un trajet - Lotocar</title>
 
 		<meta name="description" content=" " />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2910,6 +2910,23 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-trap": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+      "requires": {
+        "tabbable": "^3.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "focus-trap-react": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
+      "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
+      "requires": {
+        "focus-trap": "^4.0.2"
+      }
+    },
     "follow-redirects": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
@@ -6505,6 +6522,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "tabbable": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"esm": "^3.2.25",
 		"express": "^4.17.1",
 		"fast-memoize": "^2.5.1",
+		"focus-trap-react": "^6.0.0",
 		"geodesy": "^2.2.0",
 		"googleapis": "^41.0.1",
 		"got": "^9.6.0",


### PR DESCRIPTION
Avec un événement lors des recherches. Pour l'instant on log simplement la recherche effectuée.

Avant de merger : 
- [ ] ne plus prendre en compte le suivi 'localhost' dans piwik (simple case à cocher)

Puis rapidement : 

- [x] Faire une page de "Vie privée" (nécessité légale). Exemple [ici](https://github.com/betagouv/mon-entreprise/blob/master/source/sites/mon-entreprise.fr/layout/Footer/Privacy.tsx)
- [ ] suivre le nombre de trajets retournés pour la recherche de l'utilisateur. Il faut résoudre #75 d'abord, car aujourd'hui on calcule le détour au niveau de l'affichage du trajet, il faut le faire en amont.